### PR TITLE
Added OFI CXI Provider support to ROFI

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,12 +24,17 @@ AC_ARG_WITH([ofi],
             [OFI_PATH="$withval"],
             [OFI_PATH="/usr/local"])
 
+#AC_ARG_WITH([ofi-provider],
+#    [AC_HELP_STRING([--with-ofi-provider],
+#                    [Manually select the underlying OFI provider (e.g., verbs, default: none)])],
+#		    [AM_CONDITIONAL(WITH_OFI_PROVIDER, true)
+#		     AC_DEFINE(ROFI_OFI_PROVIDER,[$with_ofi_provider],[OFI Provider])],
+#		    [AM_CONDITIONAL(WITH_OFI_PROVIDER, false)])
+
 AC_ARG_WITH([ofi-provider],
-    [AC_HELP_STRING([--with-ofi-provider],
-                    [Manually select the underlying OFI provider (e.g., verbs, default: none)])],
-		    [AM_CONDITIONAL(WITH_OFI_PROVIDER, true)
-		     AC_DEFINE(ROFI_OFI_PROVIDER,[$with_ofi_provider],[OFI Provider])],
-		    [AM_CONDITIONAL(WITH_OFI_PROVIDER, false)])
+    [AC_HELP_STRING([--with-ofi-provider], [Manually select the OFI provider (default: verbs)])],
+    [],
+    [with_ofi_provider=verbs])
 
 AC_ARG_WITH([ofi-version],
     [AC_HELP_STRING([--with-ofi-version], [Manually specify the OFI version (default: autoselect with pkg-check)])], 
@@ -120,6 +125,20 @@ OFI_VERSION_FINAL=$(($OFI_VERSION_MAJOR * 100 + $OFI_VERSION_MINOR))
 AC_SUBST([OFI_VERSION_FINAL])
 AS_VAR_APPEND(CFLAGS, " -D__OFI_VERSION__=$OFI_VERSION_FINAL")
 
+case "$with_ofi_provider" in
+    verbs)
+      AS_VAR_APPEND(CFLAGS, " -D__OFI_PROV_VERBS__")
+      ;;
+    cxi)
+      AS_VAR_APPEND(CFLAGS, " -D__OFI_PROV_CXI__")
+      ;;
+    *)
+      AC_MSG_ERROR([Unknown or no OFI provider specified ($with_ofi_provider) (valid providers: verbs, cxi)])
+      ;;
+esac
+
+
+
 if test "$enable_debug" = "yes" ; then
   AS_VAR_APPEND(CFLAGS, " -O0 -D_DEBUG")
 fi
@@ -198,7 +217,7 @@ echo ""
 echo "Options:   "
 echo "		 Debug:		$enable_debug"
 echo "		 Stats:		$enable_stats"
-echo "		 OFI Provider:  $ROFI_OFI_PROVIDER"
+echo "		 OFI Provider:  $with_ofi_provider"
 echo "		 PMIx:		$PMIX_PATH"
 echo ""
 echo "Compilers: "

--- a/configure.ac
+++ b/configure.ac
@@ -31,6 +31,11 @@ AC_ARG_WITH([ofi-provider],
 		     AC_DEFINE(ROFI_OFI_PROVIDER,[$with_ofi_provider],[OFI Provider])],
 		    [AM_CONDITIONAL(WITH_OFI_PROVIDER, false)])
 
+AC_ARG_WITH([ofi-version],
+    [AC_HELP_STRING([--with-ofi-version], [Manually specify the OFI version (default: autoselect with pkg-check)])], 
+    [],
+    [with_ofi_version=auto])
+
 AC_ARG_WITH([pmix],
     [AS_HELP_STRING([--with-pmix@<:@=DIR@:>@],
                     [Build pmi-simple against PMIx, optionally using the installation in DIR])],
@@ -89,13 +94,31 @@ fi
 
 AC_SUBST([ASAN_CFLAGS], [$asan_cflags])
 
-LDFLAGS="$LDFLAGS -L$OFI_PATH/lib -Wl,-rpath,$OFI_PATH/lib $ASAN_CFLAGS"
+LDFLAGS="$LDFLAGS -L$OFI_PATH/lib -Wl,-rpath,$OFI_PATH/lib -L$OFI_PATH/lib64 -Wl,-rpath,$OFI_PATH/lib64 $ASAN_CFLAGS"
 CPPFLAGS="$CPPFLAGS -I$OFI_PATH/include"
 
 AC_CHECK_HEADERS([stdio.h],       [],[AC_MSG_ERROR[stdio.h  not found!]])
 AC_CHECK_HEADERS([sys/socket.h], [],[AC_MSG_ERROR[sys/socket.h  not found!]])
 AC_CHECK_HEADERS([rdma/fabric.h], [],[AC_MSG_ERROR[fabric.h not found!]])
-AC_SEARCH_LIBS([fi_getinfo], [fabric], [], [AC_MSG_ERROR[libfabric not found!]], [-libverbs -pthread -ldl -lrdmacm -lrt  -lnuma -luuid])
+#AC_SEARCH_LIBS([fi_getinfo], [fabric], [], [AC_MSG_ERROR[libfabric not found!]], [-libverbs -pthread -ldl -lrdmacm -lrt  -lnuma -luuid])
+AC_SEARCH_LIBS([fi_getinfo], [fabric], [], [AC_MSG_ERROR([Could not find libfabric library])])
+
+AS_IF([test "x$with_ofi_version" = "xauto"], [
+  OFI_VERSION_RAW=`pkg-config --modversion libfabric`
+  AC_MSG_NOTICE([Detected libfabric version $OFI_VERSION_RAW])], [
+  AC_MSG_NOTICE([Using manually specified libfabric version $with_ofi_version])
+  OFI_VERSION_RAW=$with_ofi_version])
+
+AC_SUBST([OFI_VERSION_RAW])
+OFI_VERSION_MAJOR=`echo $OFI_VERSION_RAW | awk -F. '{print $1}'`
+OFI_VERSION_MINOR=`echo $OFI_VERSION_RAW | awk -F. '{print $2}'`
+AC_SUBST([OFI_VERSION_MAJOR])
+AC_SUBST([OFI_VERSION_MINOR])
+#AC_MSG_NOTICE([Extracted major version: $OFI_VERSION_MAJOR])
+#AC_MSG_NOTICE([Extracted minor version: $OFI_VERSION_MINOR])
+OFI_VERSION_FINAL=$(($OFI_VERSION_MAJOR * 100 + $OFI_VERSION_MINOR))
+AC_SUBST([OFI_VERSION_FINAL])
+AS_VAR_APPEND(CFLAGS, " -D__OFI_VERSION__=$OFI_VERSION_FINAL")
 
 if test "$enable_debug" = "yes" ; then
   AS_VAR_APPEND(CFLAGS, " -O0 -D_DEBUG")

--- a/src/core.c
+++ b/src/core.c
@@ -278,12 +278,6 @@ void rofi_barrier_internal(void) {
     rofi_transport_barrier(&rofi);
 }
 
-#ifdef __OFI_PROV_CXI__
-void rofi_barrier_p2p_internal(void) {
-  rofi_transport_barrier_p2p(&rofi);
-}
-#endif
-
 int rofi_put_internal(void *dst, void *src, size_t size, unsigned int id, unsigned long flags) {
     rofi_mr_desc *el = mr_get(&rofi, dst);
     struct fi_rma_iov rma_iov;
@@ -624,19 +618,21 @@ int rofi_init_internal(char *provs, char *domains) {
     // (1) The following hints are based on working through the code path 
     // for the simple_write rma test included with the CXI provider in 
     // libfabric v2.1
-    // (2) The verbs provider specifies FI_DELIVERY_COMPLETE; CXI supports this, but defaults to FI_TRANSMIT_COMPLETE, 
-    // as it has lower latency. TRANSMIT vs DELIVERY does not make a difference for passing the ROFI tests. 
+    // (2) The verbs provider specifies FI_DELIVERY_COMPLETE; CXI supports this, but defaults to 
+    // FI_TRANSMIT_COMPLETE, as it has lower latency. TRANSMIT vs DELIVERY does not make 
+    // a difference for passing the ROFI tests. 
     // TODO: Will TRANSMIT break lamelar?
-    // (3) hints->tx_attr->size defaults to 1024, and is a hard cap (i.e., will abort if exceeded). A large fan-out could 
-    // cause issues. TODO: What is a safe value?
-    // (4) TODO: Since we've changed to selecting compiler at configure time, the arguments to rofi_init might be reconsidered.
-    // (5) CXI has 'optimized' memory regions for applications that will use a small number of large regions involving 
-    // many small operations. Enabling these requires manually selecting memory keys in the range 0-99 inclusive. This 
-    // in turn requires not configuring with FI_MR_PROV_KEY. Making this change may cause ripple effects across the ROFI 
-    // code. TODO: Consider whether to take this on.
+    // (3) hints->tx_attr->size defaults to 1024, and is a hard cap (i.e., will abort 
+    // if exceeded). A large fan-out could cause issues. TODO: What is a safe value?
+    // (4) CXI has 'optimized' memory regions for applications that will use a small 
+    // number of large regions involving many small operations. Enabling these requires 
+    // manually selecting memory keys in the range 0-99 inclusive. This 
+    // in turn requires not configuring with FI_MR_PROV_KEY. Making this change may 
+    // cause ripple effects across the ROFI code. TODO: Consider whether to take this on.
     // (6) TODO: Explore message ordering constraints. Currently we leave them at the defaults.
-    // (7) TODO: The CXI provider is returned with all of its capabilites active (including FI_RMA_EVENT), which is a 
-    // superset of the caps requested for the verbs provider. Test whether using the same caps as Verbs breaks anything.
+    // (7) TODO: The CXI provider is returned with all of its capabilites active (including 
+    // FI_RMA_EVENT), which is a superset of the caps requested for the verbs provider. Test 
+    // In other work we have not seen a performance impact of doing this. 
 
     hints->fabric_attr->prov_name = strdup("cxi"); // limits returned providers to cxi only
     hints->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_ALLOCATED | FI_MR_PROV_KEY; 
@@ -733,7 +729,7 @@ int rofi_init_internal(char *provs, char *domains) {
     //if (rofi.desc.nodes > 1) {
     //    rt_barrier();
     //}
-    rofi_transport_barrier_p2p(&rofi);  
+    rofi_transport_barrier_msg(&rofi);  
     //rofi_transport_barrier(&rofi);
     return 0;
 

--- a/src/core.c
+++ b/src/core.c
@@ -278,6 +278,12 @@ void rofi_barrier_internal(void) {
     rofi_transport_barrier(&rofi);
 }
 
+#ifdef __OFI_PROV_CXI__
+void rofi_barrier_p2p_internal(void) {
+  rofi_transport_barrier_p2p(&rofi);
+}
+#endif
+
 int rofi_put_internal(void *dst, void *src, size_t size, unsigned int id, unsigned long flags) {
     rofi_mr_desc *el = mr_get(&rofi, dst);
     struct fi_rma_iov rma_iov;
@@ -293,7 +299,12 @@ int rofi_put_internal(void *dst, void *src, size_t size, unsigned int id, unsign
         DEBUG_MSG("remote addr: %d %p", i, el->iov[id].addr);
     }
 
+#ifdef __OFI_PROV_CXI__
+    // if CXI, use offset instead of virtual address
+    rma_iov.addr = (uint64_t)(dst - el->start + el->iov[id].addr) - (uint64_t)el->start;
+#else
     rma_iov.addr = (uint64_t)(dst - el->start + el->iov[id].addr);
+#endif
     rma_iov.key = el->iov[id].key;
     if (rma_iov.key == 0) {
         ERR_MSG("\t No Key found for address %p on node %u", dst, id);
@@ -339,7 +350,11 @@ int rofi_get_internal(void *dst, void *src, size_t size, unsigned int id, unsign
     }
     DEBUG_MSG("\t Found MR [0x%p - 0x%p] Key: 0x%lx", el->start, el->start + el->size, el->mr_key);
 
+#ifdef __OFI_PROV_CXI__
+    rma_iov.addr = (uint64_t)(src - el->start + el->iov[id].addr) - (uint64_t)el->start;
+#else
     rma_iov.addr = (uint64_t)(src - el->start + el->iov[id].addr);
+#endif
     rma_iov.key = el->iov[id].key;
     if (rma_iov.key == 0) {
         ERR_MSG("\t No Key found for address %p on node %u", src, id);
@@ -589,6 +604,8 @@ int rofi_init_internal(char *provs, char *domains) {
         return EXIT_FAILURE;
     }
 
+#if defined (__OFI_PROV_VERBS__)
+
     hints->caps = FI_RMA | FI_ATOMIC | FI_COLLECTIVE | FI_MSG;
     hints->addr_format = FI_FORMAT_UNSPEC;
     hints->domain_attr->resource_mgmt = FI_RM_ENABLED;
@@ -598,6 +615,45 @@ int rofi_init_internal(char *provs, char *domains) {
     hints->mode = FI_CONTEXT;
     hints->ep_attr->type = FI_EP_RDM;
     hints->tx_attr->op_flags = FI_DELIVERY_COMPLETE; // maybe need to change this to FI_INJECT_COMPLETE or FI_TRANSMIT_COMPLETE
+
+#elif defined (__OFI_PROV_CXI__)
+
+    DEBUG_MSG("Process %d requesting CXI provider", rofi.desc.nid);
+
+    // NOTES: 
+    // (1) The following hints are based on working through the code path 
+    // for the simple_write rma test included with the CXI provider in 
+    // libfabric v2.1
+    // (2) The verbs provider specifies FI_DELIVERY_COMPLETE; CXI supports this, but defaults to FI_TRANSMIT_COMPLETE, 
+    // as it has lower latency. TRANSMIT vs DELIVERY does not make a difference for passing the ROFI tests. 
+    // TODO: Will TRANSMIT break lamelar?
+    // (3) hints->tx_attr->size defaults to 1024, and is a hard cap (i.e., will abort if exceeded). A large fan-out could 
+    // cause issues. TODO: What is a safe value?
+    // (4) TODO: Since we've changed to selecting compiler at configure time, the arguments to rofi_init might be reconsidered.
+    // (5) CXI has 'optimized' memory regions for applications that will use a small number of large regions involving 
+    // many small operations. Enabling these requires manually selecting memory keys in the range 0-99 inclusive. This 
+    // in turn requires not configuring with FI_MR_PROV_KEY. Making this change may cause ripple effects across the ROFI 
+    // code. TODO: Consider whether to take this on.
+    // (6) TODO: Explore message ordering constraints. Currently we leave them at the defaults.
+    // (7) TODO: The CXI provider is returned with all of its capabilites active (including FI_RMA_EVENT), which is a 
+    // superset of the caps requested for the verbs provider. Test whether using the same caps as Verbs breaks anything.
+
+    hints->fabric_attr->prov_name = strdup("cxi"); // limits returned providers to cxi only
+    hints->domain_attr->mr_mode = FI_MR_ENDPOINT | FI_MR_ALLOCATED | FI_MR_PROV_KEY; 
+    hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+    hints->domain_attr->control_progress = FI_PROGRESS_MANUAL; 
+    hints->tx_attr->size = 4096;  
+    //hints->tx_attr->op_flags = FI_DELIVERY_COMPLETE;  // default for CXI is FI_TRANSMIT_COMPLETE
+
+    // TBD: message ordering requirements (tx_attr and rx_attr)
+    // Through trial and error, we determined This will make most of them NO;
+    // hints->tx_attr->msg_order = 0;
+
+    DEBUG_MSG("ROFI Compiled for CXI support");
+
+#else
+    ERR_MSG("Invalid or no OFI provider selected during ROFI configuration!");
+#endif
 
     rofi_names_t *prov_names = NULL;
     if (provs) {
@@ -654,7 +710,8 @@ int rofi_init_internal(char *provs, char *domains) {
         rt_barrier();
     }
 
-    ret = rofi_transport_exchange_mr_info(&rofi, rofi.mr);
+    ret = rofi_transport_exchange_init_mr_info(&rofi, rofi.mr);
+    // ORIGINAL: ret = rofi_transport_exchange_mr_info(&rofi, rofi.mr);
 
     if (ret) {
         return ret;
@@ -672,7 +729,12 @@ int rofi_init_internal(char *provs, char *domains) {
         rofi.sub_alloc_buf[i].addr = 0;
     }
     fi_freeinfo(hints);
-    rofi_transport_barrier(&rofi);
+
+    //if (rofi.desc.nodes > 1) {
+    //    rt_barrier();
+    //}
+    rofi_transport_barrier_p2p(&rofi);  
+    //rofi_transport_barrier(&rofi);
     return 0;
 
 err:

--- a/src/include/rofi.h
+++ b/src/include/rofi.h
@@ -68,4 +68,5 @@ int rofi_query_compare_atomic(rofi_datatype_t, rofi_atomic_op_t);
 ssize_t rofi_atomic_op(void *, const void *, size_t, rofi_datatype_t, rofi_atomic_op_t, unsigned int);
 ssize_t rofi_atomic_fetch(void *, const void *, void *, size_t, rofi_datatype_t, rofi_atomic_op_t, unsigned int);
 ssize_t rofi_compare_atomic(void *, const void *, const void *, void *, size_t, rofi_datatype_t, rofi_atomic_op_t, unsigned int);
+
 #endif

--- a/src/include/rofi_internal.h
+++ b/src/include/rofi_internal.h
@@ -12,6 +12,11 @@
 
 #include <uthash.h>
 
+#ifdef __OFI_PROV_CXI__
+    #include <stdbool.h>
+    #include <rdma/fi_cxi_ext.h>
+#endif
+
 #ifndef ROFI_FI_VERSION
 #define ROFI_FI_VERSION FI_VERSION(1, 15)
 #endif
@@ -116,4 +121,12 @@ int rofi_query_compare_atomic_internal(rofi_datatype_t, rofi_atomic_op_t);
 ssize_t rofi_atomic_op_internal(void *, const void *, size_t, rofi_datatype_t, rofi_atomic_op_t, unsigned int);
 ssize_t rofi_atomic_fetch_internal(void *, const void *, void *, size_t, rofi_datatype_t, rofi_atomic_op_t, unsigned int);
 ssize_t rofi_compare_atomic_internal(void *, const void *, const void *, void *, size_t, rofi_datatype_t, rofi_atomic_op_t, unsigned int);
+
+// message-based barrier used once by CXI at end of rofi_init_internal
+// Note currently not exposed in the rofi API (i.e., in rofi.h or api.c)
+#ifdef __OFI_PROV_CXI__
+void rofi_barrier_p2p_internal(void);
+#endif
+
+
 #endif

--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -104,7 +104,7 @@ int rofi_transport_barrier(rofi_transport_t *rofi);
 // number of entries)
 #ifdef __OFI_PROV_CXI__
 int rofi_transport_wait_on_cq(struct fid_cq *cq, struct fi_cq_entry *cqe, const int expected_num_entries); // blocking!
-int rofi_transport_barrier_p2p(rofi_transport_t *rofi);
+int rofi_transport_barrier_msg(rofi_transport_t *rofi);
 #endif
 
 #endif /* _TRANSPORT_H_ */

--- a/src/include/transport.h
+++ b/src/include/transport.h
@@ -90,9 +90,22 @@ int rofi_transport_compare_atomic(rofi_transport_t *rofi, struct fi_rma_iov *rma
 int rofi_transport_send(rofi_transport_t *rofi, void *buf, size_t len, uint64_t pe);
 int rofi_transport_recv(rofi_transport_t *rofi, void *buf, size_t len);
 
+int rofi_transport_exchange_init_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr);
 int rofi_transport_exchange_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr);
 int rofi_transport_sub_exchange_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr, uint64_t *pes, uint64_t num_pes);
+int rofi_transport_sub_exchange_mr_info_manual(rofi_transport_t *rofi, rofi_mr_desc *mr, uint64_t *pes, uint64_t num_pes);
 int rofi_transport_inner_barrier(rofi_transport_t *rofi, uint64_t *barrier_id, uint64_t *barrier_buf, uint64_t *pes, uint64_t me, uint64_t num_pes);
 int rofi_transport_barrier(rofi_transport_t *rofi);
 
+
+// CXI uses a message-based barrier at the end of rofi_init_internal
+// This requires using at least the Rx completion queue
+// So here we have the barrier and the completion counter wait (blocking on 
+// number of entries)
+#ifdef __OFI_PROV_CXI__
+int rofi_transport_wait_on_cq(struct fid_cq *cq, struct fi_cq_entry *cqe, const int expected_num_entries); // blocking!
+int rofi_transport_barrier_p2p(rofi_transport_t *rofi);
+#endif
+
 #endif /* _TRANSPORT_H_ */
+

--- a/src/mr.c
+++ b/src/mr.c
@@ -95,7 +95,6 @@ rofi_mr_desc *mr_add(rofi_transport_t *rofi, size_t size, unsigned long mode) {
     }
 
 #ifdef __OFI_PROV_CXI__
-
     // CXI requires memory regions that can be the targets of external 
     // writes or reads be (i) registered, (ii) associated with an endpoint, 
     // and (iii) enabled.
@@ -110,7 +109,6 @@ rofi_mr_desc *mr_add(rofi_transport_t *rofi, size_t size, unsigned long mode) {
         goto err_mmap;
     }
     DEBUG_MSG("Performed fi_mr_bind and fi_mr_enable for CXI provider");
-
 #endif
 
     assert(err == 0);

--- a/src/mr.c
+++ b/src/mr.c
@@ -90,9 +90,28 @@ rofi_mr_desc *mr_add(rofi_transport_t *rofi, size_t size, unsigned long mode) {
                     &(el->fid), &(el->ctx));
 
     if (err != FI_SUCCESS) {
-        ERR_MSG("Error creating OFI memroy region (%d). Aborting.", err);
+        ERR_MSG("Error creating OFI memory region (%d). Aborting.", err);
         goto err_mmap;
     }
+
+#ifdef __OFI_PROV_CXI__
+
+    // CXI requires memory regions that can be the targets of external 
+    // writes or reads be (i) registered, (ii) associated with an endpoint, 
+    // and (iii) enabled.
+    err = fi_mr_bind(el->fid, &(rofi->ep->fid), 0);
+    if (err != FI_SUCCESS) {
+        ERR_MSG("Error binding OFI MR (%d). Aborting.", err);
+        goto err_mmap;
+    }
+    err = fi_mr_enable(el->fid);
+    if (err != FI_SUCCESS) {
+        ERR_MSG("Error enabling OFI MR (%d). Aborting.", err);
+        goto err_mmap;
+    }
+    DEBUG_MSG("Performed fi_mr_bind and fi_mr_enable for CXI provider");
+
+#endif
 
     assert(err == 0);
 

--- a/src/transport.c
+++ b/src/transport.c
@@ -565,9 +565,13 @@ int rofi_transport_progress(rofi_transport_t *rofi) {
             if (ret > 0) {
                 const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
                 const char *errmsg1 = fi_cq_strerror(rofi->cq, ebuf.err, ebuf.err_data, NULL, 0);
+#if __OFI_VERSION__ >= 120
                 ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu src_addr %d %s %s", ret,
-                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg, errmsg1
-                );
+                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg, errmsg1);
+#else
+                ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu %s %s", ret,
+                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,errmsg, errmsg1);
+#endif
                 err = ebuf.err;
             }
             else if (ret < 0) {
@@ -594,9 +598,15 @@ int rofi_transport_locked_ctx_check_err(rofi_transport_t *rofi, int err, struct 
                 int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
                 const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
                 const char *errmsg1 = fi_cq_strerror(rofi->cq, ebuf.err, ebuf.err_data, NULL, 0);
+// the src_addr field was added sometime around libfabric 1.20
+#if __OFI_VERSION__ >= 120
                 ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu src_addr %d %s %s", ret,
                             ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg, errmsg1
-                );
+#else
+                 ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu %s %s", ret,
+                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,errmsg, errmsg1);
+#endif
+
                 // struct fi_cq_err_entry ebuf = {0};
                 // int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
                 // if (ret > 0 && ebuf.err == -FI_EACCES) {
@@ -619,9 +629,13 @@ int rofi_transport_locked_ctx_check_err(rofi_transport_t *rofi, int err, struct 
                 int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
                 const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
                 const char *errmsg1 = fi_cq_strerror(rofi->cq, ebuf.err, ebuf.err_data, NULL, 0);
+#if __OFI_VERSION__ >= 120
                 ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu src_addr %d %s %s", ret,
-                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg,errmsg1
-                );
+                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg,errmsg1);
+#else
+                ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu %s %s", ret,
+                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,errmsg, errmsg1);
+#endif
             }
             return err;
         }

--- a/src/transport.c
+++ b/src/transport.c
@@ -1172,14 +1172,7 @@ int rofi_transport_sub_exchange_mr_info_manual(rofi_transport_t *rofi, rofi_mr_d
         }
     }
     struct fi_rma_iov *sub_alloc_buf = rofi->sub_alloc_buf;
-// Under CXI, the fi_rma_iov addr is an offset
-// Under Verbs, it is a virtual address
-// Commenting out because address vs offset should be determined right before commm op
-//#ifdef __OFI_PROV_CXI__
-//    sub_alloc_buf[global_me].addr = 0;
-//#else
     sub_alloc_buf[global_me].addr = (uint64_t)mr->start;
-//#endif
     sub_alloc_buf[global_me].key = fi_mr_key(mr->fid);
     DEBUG_MSG("Placing mr info (key: 0x%lx, addr: 0x%lx)... at local address: %p", sub_alloc_buf[global_me].key, sub_alloc_buf[global_me].addr, &sub_alloc_buf[global_me]);
     uint64_t sub_alloc_barrier_id = 0;
@@ -1376,7 +1369,7 @@ int rofi_transport_inner_barrier(rofi_transport_t *rofi, uint64_t *barrier_id, u
             DEBUG_MSG("%d Sending %d to %d %p - %p + %p", me, *barrier_id, send_pe, dst, rofi->mr->start, rofi->mr->iov[send_pe].addr);
             struct fi_rma_iov rma_iov;
 #ifdef __OFI_PROV_CXI__
-            // CXI uses offsets, so turn addr into offset by subtracting starting address
+            // CXI uses offsets, so turn addr into offset
             rma_iov.addr = (uint64_t)(dst - rofi->mr->start + rofi->mr->iov[send_pe].addr) - (uint64_t)rofi->mr->start;
 #else
             rma_iov.addr = (uint64_t)(dst - rofi->mr->start + rofi->mr->iov[send_pe].addr);
@@ -1412,6 +1405,8 @@ int rofi_transport_barrier(rofi_transport_t *rofi) {
 }
 
 #ifdef __OFI_PROV_CXI__
+// This and the following function are to avoid a race condition using RMA for the very first 
+// barrier at the end of initialization
 int rofi_transport_wait_on_cq(struct fid_cq *cq, struct fi_cq_entry *cqe, const int num_entries) {
   int ret;
   int count = 0;
@@ -1437,7 +1432,7 @@ int rofi_transport_wait_on_cq(struct fid_cq *cq, struct fi_cq_entry *cqe, const 
   return 0;
 }
 
-int rofi_transport_barrier_p2p(struct rofi_transport_t *rofi)
+int rofi_transport_barrier_msg(struct rofi_transport_t *rofi)
 {
   int ret;
 
@@ -1495,97 +1490,5 @@ int rofi_transport_barrier_p2p(struct rofi_transport_t *rofi)
     ret = fi_sendmsg(rofi->ep, &msg_send, 0);
   }
 }
-
-//
-// Linear (1:N followed by N:1) barrier
-//int rofi_transport_msg_barrier_linear(rofi_transport_t *rofi) {
-//  int ret;
-//  unsigned int my_rank = rofi->desc.nid;
-//  unsigned int num_ranks = rofi->desc.nodes;
-//
-//  uint8_t barrier_send_buf[1];
-//  uint8_t barrier_recv_buf[1];
-//  *barrier_send_buf = 5;
-//  *barrier_recv_buf = 0;
-//
-//  // all PEs send the same thing; only the address may change
-//  struct iovec iov_send = {&barrier_send_buf, sizeof(uint8_t)};
-//  struct fi_msg msg_send = {};
-//  msg_send.msg_iov = &iov_send;
-//  msg_send.iov_count = 1;
-//
-//  // all PEs recv to the same location (b/c we don't care about the data 
-//  // getting clobbered), but the address may change
-//  struct iovec iov_recv = {&barrier_recv_buf, sizeof(uint8_t)};
-//  struct fi_msg msg_recv = {};
-//  msg_recv.msg_iov = &iov_recv;
-//  msg_recv.iov_count = 1;
-//
-//  struct fi_cq_entry cqe = {};
-//
-//  DEBUG_MSG("rank %u entering linear barrier with recv_buf = %u", my_rank, *barrier_recv_buf);
-//
-//  if (my_rank > 0) {
-//    // each rank besides 0 posts send to 0
-//    msg_send.addr = (rofi->remote_addrs)[0];
-//    ret = fi_sendmsg(rofi->ep, &msg_send, 0);
-//    if (ret != 0) {
-//      ROFI_TRANSPORT_ERR_MSG("fi_send", ret);
-//      struct fi_cq_err_entry ebuf = {0};
-//      int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
-//      if (ret > 0) {
-//        const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
-//        ERR_MSG("Error: %s\n", errmsg);
-//        abort();
-//        return ret;
-//      }
-//    }
-//
-//    // each rank waits to hear back from 0
-//    msg_recv.addr = (rofi->remote_addrs)[0];
-//    ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
-//    // await CQ for recv entry
-//    ret = rofi_transport_await_cq_completion(rofi->cq, &cqe, 1);
-//  } else {
-//    // rank 0 receives from each other rank
-//    for (int src = 1; src < num_ranks; ++src) {
-//      msg_recv.addr = (rofi->remote_addrs)[src];
-//      ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
-//      if (ret != 0) {
-//        ROFI_TRANSPORT_ERR_MSG("fi_recv", ret);
-//        struct fi_cq_err_entry ebuf = {0};
-//        int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
-//        if (ret > 0) {
-//          const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
-//          ERR_MSG("Error: %s\n", errmsg);
-//          abort();
-//          return ret;
-//        }
-//      }
-//    }
-//    // await recvs
-//    ret = rofi_transport_await_cq_completion(rofi->cq, &cqe, num_ranks-1);
-//    // rank 0 sends back to each other rank
-//    for (int dst = 1; dst < num_ranks; ++dst) {
-//      msg_send.addr = (rofi->remote_addrs)[dst];
-//      ret = fi_sendmsg(rofi->ep, &msg_send, 0);
-//      if (ret != 0) {
-//        ROFI_TRANSPORT_ERR_MSG("fi_send", ret);
-//        struct fi_cq_err_entry ebuf = {0};
-//        int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
-//        if (ret > 0) {
-//          const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
-//          ERR_MSG("Error: %s\n", errmsg);
-//          abort();
-//          return ret;
-//        }
-//      }
-//    }
-//  }
-//
-//  DEBUG_MSG("rank %u exited linear barrier with recv_buf = %u", my_rank, *barrier_recv_buf);
-//
-//  return 0;
-//}
 
 #endif // __OFI_PROV_CXI__

--- a/src/transport.c
+++ b/src/transport.c
@@ -146,7 +146,7 @@ void rofi_transport_select_provider(struct fi_info *prov, rofi_transport_t *rofi
     struct fi_info *prov_found = NULL;
     if (prov_names == NULL && domain_names == NULL) {
         rofi->info = fi_dupinfo(prov_cur);
-        WARN_MSG("No matches for the specified provider and/or domain", prov_names, domain_names);
+        WARN_MSG("No matches for the specified provider and/or domain: NULL NULL");
         WARN_MSG("Using first available provider: %s %s", prov_cur->fabric_attr->prov_name, prov_cur->domain_attr->name);
         
         return;
@@ -200,9 +200,28 @@ void rofi_transport_select_provider(struct fi_info *prov, rofi_transport_t *rofi
 }
 
 int rofi_transport_init(struct fi_info *hints, rofi_transport_t *rofi, rofi_names_t *prov_names, rofi_names_t *domain_names) {
+    int ofi_version_major = 0;
+    int ofi_version_minor = 0;
+
+    // The libfabric version should be set during configure time and exported to 
+    // the compiler via __OFI_VERSION__. To allow for preprocessor boolean 
+    // checks, major and minor versions are combined according to 
+    // (major * 100 + minor). Here we extract the major and minor versions for 
+    // later use by fi_getinfo.
+#ifndef __OFI_VERSION__
+    ERR_MSG("__OFI_VERSION__ was not defined at compile time!");
+    abort();
+#else
+    ofi_version_major = __OFI_VERSION__ / 100;
+    ofi_version_minor = __OFI_VERSION__ - (ofi_version_major * 100);
+    DEBUG_MSG("ROFI compiled for use with libfabric %d.%d\n", ofi_version_major, ofi_version_minor);
+    
+#endif
+
     DEBUG_MSG("fi_getinfo");
     struct fi_info *prov = fi_allocinfo();
-    int ret = fi_getinfo(ROFI_FI_VERSION, NULL, NULL, 0, hints, &prov);
+    //int ret = fi_getinfo(ROFI_FI_VERSION, NULL, NULL, 0, hints, &prov);
+    int ret = fi_getinfo(FI_VERSION(ofi_version_major, ofi_version_minor), NULL, NULL, 0, hints, &prov);
     if (ret) {
         ROFI_TRANSPORT_ERR_MSG("fi_getinfo", ret);
     }    
@@ -280,6 +299,20 @@ int rofi_transport_init(struct fi_info *hints, rofi_transport_t *rofi, rofi_name
         DEBUG_MSG("Selected atomic: no");
     } 
 
+#ifdef __OFI_PROV_CXI__
+    // The CXI tests in libfabric 2.1 follow up the selection of the 
+    // CXI provider with some additional adjustments to the fi_info struct 
+    // before initializing the fabric, creating the endpoint, etc.
+    // It is not clear they are necessary but they are repeated here.
+    // Before these adjustments, fi_getinfo will return cxi providers with all of 
+    // the capabilities (including RMA) except FI_SOURCE and FI_SOURCE_ERR
+    // Note: CXI man pages for 2.3.1 suggest not turning on FI_SOURCE/FI_SOURCE_ERR
+    rofi->info->ep_attr->tx_ctx_cnt = rofi->info->domain_attr->tx_ctx_cnt;
+    rofi->info->ep_attr->rx_ctx_cnt = rofi->info->domain_attr->rx_ctx_cnt;
+//    rofi->info->caps |= FI_SOURCE | FI_SOURCE_ERR;
+//    rofi->info->rx_attr->caps |= FI_SOURCE | FI_SOURCE_ERR;
+#endif
+
     ret = rofi_transport_init_fabric_resources(rofi);
     if (ret) {
         // already would have printed the error.
@@ -330,6 +363,7 @@ int rofi_transport_init(struct fi_info *hints, rofi_transport_t *rofi, rofi_name
         // already would have printed the error.
         return ret;
     }
+
     return 0;
 }
 
@@ -425,6 +459,12 @@ int rofi_transport_init_endpoint_resources(rofi_transport_t *rofi) {
         return ret;
     }
 
+    // The original verbs code (in the #else branch, below) makes adjustments to the 
+    // fi_info struct containing information for the selected provider at this point. This is not 
+    // required for CXI, so this directive removes it for CXI.
+#ifdef __OFI_PROV_CXI__
+    ;
+#else
     rofi->info->ep_attr->tx_ctx_cnt = 0;
     rofi->info->caps = FI_RMA | FI_WRITE | FI_READ | FI_REMOTE_WRITE | FI_REMOTE_READ | FI_ATOMIC | rofi->fi_collective;
     rofi->info->tx_attr->op_flags = FI_DELIVERY_COMPLETE; // FI_TRANSMIT_COMPLETE fails, FI_DELIVERY_COMPLETE works but I dont see a difference?
@@ -435,6 +475,7 @@ int rofi_transport_init_endpoint_resources(rofi_transport_t *rofi) {
     rofi->info->tx_attr->size = 1024;
     rofi->info->tx_attr->caps = rofi->info->caps;
     rofi->info->rx_attr->caps = FI_RECV | rofi->fi_collective; // to drive progress
+#endif
 
     DEBUG_MSG("rofi->info: %p, provider: %s, caps: 0x%lx\n",
         rofi->info, rofi->info->fabric_attr->prov_name, rofi->info->caps);
@@ -1060,6 +1101,29 @@ int rofi_transport_recv(rofi_transport_t *rofi, void *buf, size_t len) {
     return 0;
 }
 
+// New function to be used only during rofi_init_internal to exchange addressing information 
+// for the rofi.mr used for subsequent exchanges, barriers, etc.
+int rofi_transport_exchange_init_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr) {
+
+    struct fi_rma_iov rma_iov;
+    rma_iov.addr = (uint64_t)mr->start;
+    rma_iov.key = fi_mr_key(mr->fid);
+    DEBUG_MSG("Exchanging initialization (rofi.mr) MR Info (key: 0x%lx, addr: 0x%lx)....", rma_iov.key, rma_iov.addr);
+
+    int ret = rt_exchange_data("mr_init_info", &rma_iov, sizeof(struct fi_rma_iov), mr->iov, rofi->desc.nid, rofi->desc.nodes);
+    if (ret) {
+        ERR_MSG("Error exchanging info for memory region alloc buffer. Aborting!");
+        return ret;
+    }
+
+#ifdef _DEBUG
+    for (int i = 0; i < rofi->desc.nodes; i++) {
+        DEBUG_MSG("\t Results of exchanging inital MR info: Node: %d Key: 0x%lx Addr: 0x%lx", i, mr->iov[i].key, mr->iov[i].addr);
+    }
+#endif
+    return 0;
+}
+
 int rofi_transport_exchange_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr) {
     if (rofi->desc.nodes == 1) {
         return 0;
@@ -1070,6 +1134,7 @@ int rofi_transport_exchange_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr) {
     for (uint64_t i = 0; i < rofi->desc.nodes; i++) {
         pes[i] = i;
     }
+
     int ret = rofi_transport_sub_exchange_mr_info(rofi, mr, pes, rofi->desc.nodes);
     free(pes);
     return ret;
@@ -1107,7 +1172,14 @@ int rofi_transport_sub_exchange_mr_info_manual(rofi_transport_t *rofi, rofi_mr_d
         }
     }
     struct fi_rma_iov *sub_alloc_buf = rofi->sub_alloc_buf;
+// Under CXI, the fi_rma_iov addr is an offset
+// Under Verbs, it is a virtual address
+// Commenting out because address vs offset should be determined right before commm op
+//#ifdef __OFI_PROV_CXI__
+//    sub_alloc_buf[global_me].addr = 0;
+//#else
     sub_alloc_buf[global_me].addr = (uint64_t)mr->start;
+//#endif
     sub_alloc_buf[global_me].key = fi_mr_key(mr->fid);
     DEBUG_MSG("Placing mr info (key: 0x%lx, addr: 0x%lx)... at local address: %p", sub_alloc_buf[global_me].key, sub_alloc_buf[global_me].addr, &sub_alloc_buf[global_me]);
     uint64_t sub_alloc_barrier_id = 0;
@@ -1214,6 +1286,9 @@ int rofi_transport_sub_exchange_mr_info(rofi_transport_t *rofi, rofi_mr_desc *mr
     }
     DEBUG_MSG("Joined collective");
 
+    // __OFI_PFOV_CXI__
+    // NOTE: Currently CXI does not provide allgather as an OFI collective, so this code path is not followed
+    // However, if it were, it would error because addresses are still virtual and need to be converted to offsets
     struct fi_rma_iov rma_iov;
     rma_iov.addr = (uint64_t)mr->start;
     rma_iov.key = fi_mr_key(mr->fid);
@@ -1300,7 +1375,12 @@ int rofi_transport_inner_barrier(rofi_transport_t *rofi, uint64_t *barrier_id, u
 
             DEBUG_MSG("%d Sending %d to %d %p - %p + %p", me, *barrier_id, send_pe, dst, rofi->mr->start, rofi->mr->iov[send_pe].addr);
             struct fi_rma_iov rma_iov;
+#ifdef __OFI_PROV_CXI__
+            // CXI uses offsets, so turn addr into offset by subtracting starting address
+            rma_iov.addr = (uint64_t)(dst - rofi->mr->start + rofi->mr->iov[send_pe].addr) - (uint64_t)rofi->mr->start;
+#else
             rma_iov.addr = (uint64_t)(dst - rofi->mr->start + rofi->mr->iov[send_pe].addr);
+#endif
             rma_iov.key = rofi->mr->iov[send_pe].key;
             DEBUG_MSG("%d Sending barrier_id %lu to PE %d at remote addr 0x%lx with key 0x%lx", me, *barrier_id, send_pe, rma_iov.addr, rma_iov.key);
             ret = rofi_transport_put(rofi, &rma_iov, send_pe, src, sizeof(uint64_t), rofi->mr->mr_desc, NULL);
@@ -1330,3 +1410,182 @@ int rofi_transport_inner_barrier(rofi_transport_t *rofi, uint64_t *barrier_id, u
 int rofi_transport_barrier(rofi_transport_t *rofi) {
     return rofi_transport_inner_barrier(rofi, &rofi->global_barrier_id, rofi->global_barrier_buf, NULL, rofi->desc.nid, rofi->desc.nodes);
 }
+
+#ifdef __OFI_PROV_CXI__
+int rofi_transport_wait_on_cq(struct fid_cq *cq, struct fi_cq_entry *cqe, const int num_entries) {
+  int ret;
+  int count = 0;
+
+  while (count < num_entries) {
+    do {
+      ret = fi_cq_read(cq, cqe, 1);
+    } while (ret == -FI_EAGAIN);
+
+    if (ret != 1) {
+      ROFI_TRANSPORT_ERR_MSG("fi_cq_read", ret);
+      struct fi_cq_err_entry ebuf = {0};
+      int ret = fi_cq_readerr(cq, (void *)&ebuf, 0);
+      if (ret > 0) {
+        const char *errmsg = fi_cq_strerror(cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
+        ERR_MSG("Error: %s\n", errmsg);
+        abort();
+        return ret;
+      }
+    }
+    count++;
+  }
+  return 0;
+}
+
+int rofi_transport_barrier_p2p(struct rofi_transport_t *rofi)
+{
+  int ret;
+
+  unsigned int my_rank = rofi->desc.nid;
+  unsigned int num_ranks = rofi->desc.nodes;
+  struct fi_cq_entry cqe = {};
+  uint8_t barrier_send_buf[1]; // buffer used for sends in the barrier
+  uint8_t barrier_recv_buf[1]; // ditto but for recvs
+
+  struct iovec iov_send = {barrier_send_buf, sizeof(uint8_t)};
+  struct fi_msg msg_send = {};
+  msg_send.msg_iov = &iov_send;
+  msg_send.iov_count = 1;
+
+  struct iovec iov_recv = {barrier_recv_buf, sizeof(uint8_t)};
+  struct fi_msg msg_recv = {};
+  msg_recv.msg_iov = &iov_recv;
+  msg_recv.iov_count = 1;
+
+  int parent = floor((my_rank-1)/2);
+  int left_child = (2 * my_rank) + 1;
+  int right_child = 2 * (my_rank + 1);
+
+  int num_waits = 0;
+
+  if (right_child < num_ranks) {
+    num_waits++;
+    msg_recv.addr = (rofi->remote_addrs)[right_child];
+    ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
+  }
+  if (left_child < num_ranks) {
+    num_waits++;
+    msg_recv.addr = (rofi->remote_addrs)[left_child];
+    ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
+  }
+  if (num_waits > 0) {
+    ret = rofi_transport_wait_on_cq(rofi->cq, &cqe, num_waits);
+  }
+  if (my_rank > 0) {
+    msg_send.addr = (rofi->remote_addrs)[parent];
+    ret = fi_sendmsg(rofi->ep, &msg_send, 0);
+  }
+
+  if (my_rank > 0) {
+    msg_recv.addr = rofi->remote_addrs[parent];
+    ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
+    ret = rofi_transport_wait_on_cq(rofi->cq, &cqe, 1);
+  }
+  if (left_child < num_ranks) {
+    msg_send.addr = (rofi->remote_addrs)[left_child];
+    ret = fi_sendmsg(rofi->ep, &msg_send, 0);
+  }
+  if (right_child < num_ranks) {
+    msg_send.addr = (rofi->remote_addrs)[right_child];
+    ret = fi_sendmsg(rofi->ep, &msg_send, 0);
+  }
+}
+
+//
+// Linear (1:N followed by N:1) barrier
+//int rofi_transport_msg_barrier_linear(rofi_transport_t *rofi) {
+//  int ret;
+//  unsigned int my_rank = rofi->desc.nid;
+//  unsigned int num_ranks = rofi->desc.nodes;
+//
+//  uint8_t barrier_send_buf[1];
+//  uint8_t barrier_recv_buf[1];
+//  *barrier_send_buf = 5;
+//  *barrier_recv_buf = 0;
+//
+//  // all PEs send the same thing; only the address may change
+//  struct iovec iov_send = {&barrier_send_buf, sizeof(uint8_t)};
+//  struct fi_msg msg_send = {};
+//  msg_send.msg_iov = &iov_send;
+//  msg_send.iov_count = 1;
+//
+//  // all PEs recv to the same location (b/c we don't care about the data 
+//  // getting clobbered), but the address may change
+//  struct iovec iov_recv = {&barrier_recv_buf, sizeof(uint8_t)};
+//  struct fi_msg msg_recv = {};
+//  msg_recv.msg_iov = &iov_recv;
+//  msg_recv.iov_count = 1;
+//
+//  struct fi_cq_entry cqe = {};
+//
+//  DEBUG_MSG("rank %u entering linear barrier with recv_buf = %u", my_rank, *barrier_recv_buf);
+//
+//  if (my_rank > 0) {
+//    // each rank besides 0 posts send to 0
+//    msg_send.addr = (rofi->remote_addrs)[0];
+//    ret = fi_sendmsg(rofi->ep, &msg_send, 0);
+//    if (ret != 0) {
+//      ROFI_TRANSPORT_ERR_MSG("fi_send", ret);
+//      struct fi_cq_err_entry ebuf = {0};
+//      int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
+//      if (ret > 0) {
+//        const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
+//        ERR_MSG("Error: %s\n", errmsg);
+//        abort();
+//        return ret;
+//      }
+//    }
+//
+//    // each rank waits to hear back from 0
+//    msg_recv.addr = (rofi->remote_addrs)[0];
+//    ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
+//    // await CQ for recv entry
+//    ret = rofi_transport_await_cq_completion(rofi->cq, &cqe, 1);
+//  } else {
+//    // rank 0 receives from each other rank
+//    for (int src = 1; src < num_ranks; ++src) {
+//      msg_recv.addr = (rofi->remote_addrs)[src];
+//      ret = fi_recvmsg(rofi->ep, &msg_recv, FI_COMPLETION);
+//      if (ret != 0) {
+//        ROFI_TRANSPORT_ERR_MSG("fi_recv", ret);
+//        struct fi_cq_err_entry ebuf = {0};
+//        int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
+//        if (ret > 0) {
+//          const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
+//          ERR_MSG("Error: %s\n", errmsg);
+//          abort();
+//          return ret;
+//        }
+//      }
+//    }
+//    // await recvs
+//    ret = rofi_transport_await_cq_completion(rofi->cq, &cqe, num_ranks-1);
+//    // rank 0 sends back to each other rank
+//    for (int dst = 1; dst < num_ranks; ++dst) {
+//      msg_send.addr = (rofi->remote_addrs)[dst];
+//      ret = fi_sendmsg(rofi->ep, &msg_send, 0);
+//      if (ret != 0) {
+//        ROFI_TRANSPORT_ERR_MSG("fi_send", ret);
+//        struct fi_cq_err_entry ebuf = {0};
+//        int ret = fi_cq_readerr(rofi->cq, (void *)&ebuf, 0);
+//        if (ret > 0) {
+//          const char *errmsg = fi_cq_strerror(rofi->cq, ebuf.prov_errno, ebuf.err_data, NULL, 0);
+//          ERR_MSG("Error: %s\n", errmsg);
+//          abort();
+//          return ret;
+//        }
+//      }
+//    }
+//  }
+//
+//  DEBUG_MSG("rank %u exited linear barrier with recv_buf = %u", my_rank, *barrier_recv_buf);
+//
+//  return 0;
+//}
+
+#endif // __OFI_PROV_CXI__

--- a/src/transport.c
+++ b/src/transport.c
@@ -601,9 +601,9 @@ int rofi_transport_locked_ctx_check_err(rofi_transport_t *rofi, int err, struct 
 // the src_addr field was added sometime around libfabric 1.20
 #if __OFI_VERSION__ >= 120
                 ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu src_addr %d %s %s", ret,
-                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg, errmsg1
+                            ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,ebuf.src_addr,errmsg, errmsg1);
 #else
-                 ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu %s %s", ret,
+                ERR_MSG("ret: %d context: %p flags %llu len: %d buf: %p data: %llu tag %llu olen %llu err %d prov_err %d err_data %p err_data_size %llu %s %s", ret,
                             ebuf.op_context,ebuf.flags,ebuf.len,ebuf.buf,ebuf.data, ebuf.tag,ebuf.olen,ebuf.err,ebuf.prov_errno,ebuf.err_data,ebuf.err_data_size,errmsg, errmsg1);
 #endif
 


### PR DESCRIPTION
This PR contains changes to support the OFI CXI (HPE Cray Slingshot) provider in ROFI. There are two main groups of changes (and then some things that are not in this PR):

1. For configure (configure.ac, changes to src to use new flags)
    - --with-ofi-provider now accepts "cxi". Sets __OFI_PROV_VERBS__ or __OFI_PROV_CXI__ (default is verbs)
    - Added --with-ofi-version; new option defaults to auto-selecting ofi version using pkg-check, but can be manually overridden. Sets __OFI_VERSION__.
    - Fixed bug in check for libfabric library (extra arguments caused check to fail on Sandia systems)
    - Added preprocessor directives to .h/.c to use new flags set during configure. These fall into 2 categories: (1) directives to take into account different OFI versions; (2) directives to add CXI support.
    - Tested that the changes to configure work on a Slingshot 2.3.1 system, a Slingshot 1.15.2 system, and a UCX/Verbs system.

2. For supporting CXI
    - Changes to support CXI all involve the __OFI_PROV_CXI__ preprocessor variable, and are scattered around the code.
    - Added alternative fi_hints to select CXI provider.
    - Added FI_MSG based barrier (rofi_transport_barrier_msg) and a supporting function to query the completion queue (rofi_transport_wait_on_cq) used once by CXI at the conclusion of rofi_init_internal. This is required to avoid a suspected race condition.
    - Added code to adjust virtual-address (Verbs) based addressing to offset-based addressing (CXI).
    - Added code to do additional memory registration steps as required by CXI
    - Tested on Slingshot 2.3.1 system and UCX/Verbs (IB) system.

3. Not covered in this PR:
    - ROFI will report that a provider is not specified (NULL NULL); this is because provider selection is no longer done using rofi_init but rather through configure (so ROFI does find the provider). Fix coming later.
    - Since CXI does not have a provider-supplied allgather, you will see libfabric throw a non-fatal error for each process when it fails the test for the collective.
    - Tests may not compile out of the box; saved for a future PR.
    - Support for atomics under CXI
    - Have not yet looked into doing virtual-vs-offset address correction via macro.